### PR TITLE
Implemented get-operation connection + getRecent

### DIFF
--- a/api/get/getConn.php
+++ b/api/get/getConn.php
@@ -1,0 +1,7 @@
+<?php
+    $target = "mysql:host=localhost;dbname=redacted";
+    $user = "redacted";
+    $pass = "redacted";
+
+    $conn = new PDO($target, $user, $pass);
+    ?>

--- a/api/get/getRecent.php
+++ b/api/get/getRecent.php
@@ -1,0 +1,19 @@
+<?php
+error_reporting(E_ALL);
+    require(__DIR__.'/getConn.php');
+
+    $data = $conn->query("SELECT * FROM Stock ORDER BY DateAdded LIMIT 12");
+
+    $rows = $data->fetchAll();
+
+    $json;
+    $i = 0;
+    foreach($rows as $row){
+        $json[$i] = $row;
+        $i++;
+    }
+
+    $response = json_encode($json);
+
+    echo $response;
+    ?>


### PR DESCRIPTION
This connection and all api calls that use it will be restricted to SELECTing from the 2 tables in the stock database that represent store items and their specifications.